### PR TITLE
excluded node_modules directory tailwind look up

### DIFF
--- a/html/tailwind.config.js
+++ b/html/tailwind.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-  content: ["./**/*.{html,js}"],
+  content: ["./**/*.{html,js}", "!./**/node_modules/**"],
   theme: {
     extend: {},
   },


### PR DESCRIPTION
Added regex to exclude node_modules folder from tailwind lookup which was slowing down the build time and also generating warning
Closes #47 