### PR TITLE
Linting and Static Type Checking 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,8 @@ dynamic = ["version", "license"]
 
 [project.optional-dependencies]
 dev = [
-  "ruff"
+  "ruff",
+  "mypy"
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,11 @@ classifiers = [
 dependencies = ["rich", "click", "typing_extensions", "ujson", "configzen", "psutil", "plotext"]
 dynamic = ["version", "license"]
 
+[project.optional-dependencies]
+dev = [
+  "ruff"
+]
+
 [project.urls]
 Documentation = "https://view.zintensity.dev"
 Issues = "https://github.com/ZeroIntensity/view.py/issues"


### PR DESCRIPTION
This resolves #34.

## Summary of Changes


This Pull Request adds the following features:
- Linting using [ruff](https://docs.astral.sh/ruff/)
- Static type checking using [mypy](https://mypy-lang.org/)

### Linter Choice
I researched both `flake8` and `ruff` and ultimately decided on `ruff` due to its [pyproject.toml configuration support](https://docs.astral.sh/ruff/configuration/), which is [not currently supported by flake8](https://pypi.org/project/Flake8-pyproject/).

Please let me know if you agree with this decision.
### Addition as Optional Dependencies
I decided to include `ruff` and `mypy` as [optional dependencies](https://peps.python.org/pep-0631/#optional-dependencies) (under `[project.optional-dependencies] -> dev`) rather than as a core dependency (under `[project]`) as these dependencies will support development and testing rather than production.

The project can be installed with these dependencies included by running:
```
pip install .[dev]
```

### Other Changes
Please let me know if changes to this PR are required.

Additionally, if this PR is approved and merged, I would like this contribution to count towards my [Hacktoberfest 2023](https://hacktoberfest.com/participation/) progress.
If the above changes are approved and merged, could the `hacktoberfest-accepted` label be added to the PR/MR?

Thank you for considering these changes.