### PR TITLE
Fix Synchronous Routes

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,7 +39,7 @@ jobs:
               run: pip install --upgrade --pre ward
 
             - name: Install project
-              run: pip install .[templates]
+              run: pip install .[full]
 
             - name: Run tests
               run: ward

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added environment prefixes for database configuration
 - Added `templates` and `TemplatesConfig` to config
 - Added the `templates` function
-- Added support for `attrs` in type validation.
+- Added support for `attrs` in type validation
+- Removed `psutil` and `plotext` as a global dependency
+- Added `fancy` optional dependencies
+- Fixed route inputs with synchronous routes
+- **Breaking Change:** Route inputs are now applied in the order of the decorator call as it appears in code
 
 ## [1.0.0-alpha7] - 2023-12-7
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,20 @@ databases = [
 ]
 templates = ["beautifulsoup4", "jinja2", "mako", "django", "chameleon"]
 fancy = ["psutil", "plotext"]
+full = [
+    "psutil",
+    "plotext",
+    "beautifulsoup4",
+    "jinja2",
+    "mako",
+    "django",
+    "chameleon",
+    "attrs",
+    "psycopg2-binary",
+    "mysql-connector-python",
+    "pymongo",
+    "aiosqlite"
+]
 
 [project.urls]
 Documentation = "https://view.zintensity.dev"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,11 +26,8 @@ dependencies = [
     "typing_extensions",
     "ujson",
     "configzen",
-    "psutil",
-    "plotext",
     "uvicorn",
     "aiofiles",
-    "aiohttp",
 ]
 dynamic = ["version", "license"]
 
@@ -46,6 +43,7 @@ databases = [
     "aiosqlite"
 ]
 templates = ["beautifulsoup4", "jinja2", "mako", "django", "chameleon"]
+fancy = ["psutil", "plotext"]
 
 [project.urls]
 Documentation = "https://view.zintensity.dev"

--- a/src/view/_loader.py
+++ b/src/view/_loader.py
@@ -141,7 +141,7 @@ def _format_body(
             default=default,
         )
         vbody_defaults[k] = default
-
+    
     return [
         (TYPECODE_CLASSTYPES, k, v, vbody_defaults[k])
         for k, v in vbody_final.items()
@@ -443,6 +443,7 @@ def finalize(routes: list[Route], app: ViewApp):
                     )
                 )
         app.loaded_routes.append(route)
+        route.inputs = [i for i in reversed(route.inputs)]
         target(
             route.path,  # type: ignore
             route.func,

--- a/src/view/_loader.py
+++ b/src/view/_loader.py
@@ -421,6 +421,7 @@ def finalize(routes: list[Route], app: ViewApp):
             virtual_routes[route.path or ""] = [route]
 
         sig = inspect.signature(route.func)
+        route.inputs = [i for i in reversed(route.inputs)]
         if len(sig.parameters) != len(route.inputs):
             names = [i.name for i in route.inputs]
             for k, v in sig.parameters.items():
@@ -443,7 +444,6 @@ def finalize(routes: list[Route], app: ViewApp):
                     )
                 )
         app.loaded_routes.append(route)
-        route.inputs = [i for i in reversed(route.inputs)]
         target(
             route.path,  # type: ignore
             route.func,

--- a/src/view/_util.py
+++ b/src/view/_util.py
@@ -19,7 +19,6 @@ from rich.panel import Panel
 from rich.syntax import Syntax
 from typing_extensions import Annotated, TypeGuard
 
-from ._logging import Internal
 from .exceptions import NotLoadedWarning, NeedsDependencyError
 from rich.markup import escape
 try:
@@ -147,6 +146,7 @@ def make_hint(
 
 
 def run_path(path: str | Path) -> dict[str, Any]:
+    from ._logging import Internal
     sys.path.append(str(Path(path).parent.absolute()))
     path = str(Path(path).absolute())
     Internal.info(f"running: {path}")

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -540,3 +540,28 @@ async def _():
         assert (await test.get("/", query={"test": {"a": "b", "b": 0, "c": [1]}})).status == 400
         assert (await test.get("/", query={"test": {"a": "b", "b": 0, "c": [], "d": {"a": "b"}}})).status == 400
         assert (await test.get("/", query={"test": {"a": "b", "b": 0, "c": [], "d": {"a": 0}}})).message == "b"
+
+@test("synchronous route inputs")
+async def _():
+    app = new_app()
+
+    @app.get("/")
+    @app.query("test", str)
+    def index(test: str):
+        return test
+
+    @app.get("/body")
+    @app.body("test", str)
+    def bd(test: str):
+        return test
+
+    @app.get("/both")
+    @app.body("a", str)
+    @app.query("b", str)
+    def both(a: str, b: str):
+        return a + b
+
+    async with app.test() as test:
+        assert (await test.get("/", query={"test": "a"})).message == "a"
+        assert (await test.get("/body", body={"test": "b"})).message == "b"
+        assert (await test.get("/both", body={"a": "a"}, query={"b": "b"})).message == "ab"

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -72,9 +72,9 @@ def _():
 #### Query Parameters
 | Name | Description | Type | Default |
 | - | - | - | - |
-| contacts | Your phone contacts. | `object<string, integer>` | **Required** |
-| favorite_color | Your favorite color. | `string` | **Required** |
 | person | Your info. | `Person` | **Required** |
+| favorite_color | Your favorite color. | `string` | **Required** |
+| contacts | Your phone contacts. | `object<string, integer>` | **Required** |
 #### Body Parameters
 | Name | Description | Type | Default |
 | - | - | - | - |


### PR DESCRIPTION
This closes #101.

**This introduces a breaking API change.** Route inputs are now applied in the order that they are appear in code, instead of the order they are applied as decorators. For example, the below now works as intended:

```py
from view import new_app

app = new_app()

@app.get("/")
@app.query("a", str)
@app.query("b", str)
async def index(a: str, b: str) -> None:
    return a + b

app.run()
```