### PR TITLE
Fixed possible loss of data warning when compiling for x64.

### DIFF
--- a/src/_view/awaitable.c
+++ b/src/_view/awaitable.c
@@ -546,7 +546,7 @@ PyAwaitable_SaveValues(PyObject *awaitable, Py_ssize_t nargs, ...) {
 
     va_list vargs;
     va_start(vargs, nargs);
-    int offset = aw->aw_values_size;
+    Py_ssize_t offset = aw->aw_values_size;
 
     if (aw->aw_values == NULL)
         aw->aw_values = PyMem_Calloc(
@@ -567,7 +567,7 @@ PyAwaitable_SaveValues(PyObject *awaitable, Py_ssize_t nargs, ...) {
 
     aw->aw_values_size += nargs;
 
-    for (int i = offset; i < aw->aw_values_size; i++)
+    for (Py_ssize_t i = offset; i < aw->aw_values_size; i++)
         aw->aw_values[i] = Py_NewRef(va_arg(vargs, PyObject*));
 
     va_end(vargs);
@@ -622,7 +622,7 @@ PyAwaitable_SaveArbValues(PyObject *awaitable, Py_ssize_t nargs, ...) {
 
     va_list vargs;
     va_start(vargs, nargs);
-    int offset = aw->aw_arb_values_size;
+    Py_ssize_t offset = aw->aw_arb_values_size;
 
     if (aw->aw_arb_values == NULL)
         aw->aw_arb_values = PyMem_Calloc(
@@ -643,7 +643,7 @@ PyAwaitable_SaveArbValues(PyObject *awaitable, Py_ssize_t nargs, ...) {
 
     aw->aw_arb_values_size += nargs;
 
-    for (int i = offset; i < aw->aw_arb_values_size; i++)
+    for (Py_ssize_t i = offset; i < aw->aw_arb_values_size; i++)
         aw->aw_arb_values[i] = va_arg(vargs, void *);
 
     va_end(vargs);


### PR DESCRIPTION
When compiling for x86 this is fine because Py_ssize_t is typedef'd to ``int``, however on x64 it is typedef'd to ``long long`` and so ``int`` here is a downcast and can result in "data loss". As such it is best to use ``Py_ssize_t`` instead here on these and permanently silent these warnings as the type would of these variables would automatically adjust based on the definition of ``Py_ssize_t``.