### PR TITLE
Migration of Test Suite from Ward to Pytest

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,7 +45,7 @@ jobs:
               shell: bash
     
             - name: Build project
-              run: pip install .
+              run: pip install .[full]
 
             - name:  Run tests
               run:   |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,7 +24,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                os: [ubuntu-latest, windows-latest, macos-latest]
+                os: [ubuntu-latest, windows-latest, macos-12]
                 python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
         steps:
@@ -35,11 +35,23 @@ jobs:
               with:
                   python-version: ${{ matrix.python-version }}
 
-            - name: Install Ward
-              run: pip install --upgrade --pre ward
+            - name:  Install PyTest
+              run:   |
+                     if [ "$RUNNER_OS" == "Windows" ]; then
+                          pip install pytest pytest-asyncio
+                     else
+                          pip install pytest pytest-asyncio pytest-memray
+                     fi
+              shell: bash
+    
+            - name: Build project
+              run: pip install .
 
-            - name: Install project
-              run: pip install .[full]
-
-            - name: Run tests
-              run: ward
+            - name:  Run tests
+              run:   |
+                     if [ "$RUNNER_OS" == "Windows" ]; then
+                          pytest
+                     else
+                          pytest --memray
+                     fi
+              shell: bash

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -350,6 +350,22 @@ async def test_dict_validation():
 
 
 @pytest.mark.asyncio
+async def test_non_async_routes():
+    app = new_app()
+
+    @app.get("/")
+    def index():
+        return "hello world", 201, {"a":"b"}
+    
+    async with app.test() as test:
+        res = await test.get("/")
+
+        assert res.message == "hello world"
+        assert res.status == 201
+        assert res.headers["a"] == "b"
+
+
+@pytest.mark.asyncio
 async def test_list_validation():
     app = new_app()
 
@@ -530,7 +546,7 @@ async def test_caching():
 
     
 @pytest.mark.asyncio
-async def test_asynchronous_route_inputs():
+async def test_synchronous_route_inputs():
     app = new_app()
 
     @app.get("/")

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -6,7 +6,7 @@ from pydantic import BaseModel, Field
 from typing_extensions import NotRequired
 import pytest
 
-from view import JSON, BodyParam, Context, Response, body, context, get, new_app, quey
+from view import JSON, BodyParam, Context, Response, body, context, get, new_app, query
 from view import route as route_impl
 
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -4,40 +4,38 @@ from typing import Dict, List, NamedTuple, TypedDict, Union
 import attrs
 from pydantic import BaseModel, Field
 from typing_extensions import NotRequired
-from ward import test
+import pytest
 
-from view import JSON, BodyParam, Context, Response, body, context, get, new_app, query
+from view import JSON, BodyParam, Context, Response, body, context, get, new_app, quey
 from view import route as route_impl
 
 
-@test("responses")
-async def _():
+@pytest.mark.asyncio
+async def test_reponses():
     app = new_app()
 
     @app.get("/")
     async def index():
         return "hello"
-
+    
     async with app.test() as test:
         assert (await test.get("/")).message == "hello"
 
-
-@test("status codes")
-async def _():
+@pytest.mark.asyncio
+async def test_status_codes():
     app = new_app()
 
     @app.get("/")
     async def index():
         return "error", 400
-
+    
     async with app.test() as test:
         res = await test.get("/")
         assert res.status == 400
         assert res.message == "error"
 
-
-@test("headers")
-async def _():
+@pytest.mark.asyncio
+async def test_headers():
     app = new_app()
 
     @app.get("/")
@@ -49,9 +47,8 @@ async def _():
         assert res.headers["a"] == "b"
         assert res.message == "hello"
 
-
-@test("combination of headers, responses, and status codes")
-async def _():
+@pytest.mark.asyncio
+async def test_combination_of_headers_responses_and_status_codes():
     app = new_app()
 
     @app.get("/")
@@ -64,9 +61,8 @@ async def _():
         assert res.message == "123"
         assert res.headers["a"] == "b"
 
-
-@test("result protocol")
-async def _():
+@pytest.mark.asyncio
+async def test_result_protocol():
     app = new_app()
 
     class MyObject:
@@ -87,9 +83,8 @@ async def _():
         assert res.message == "hello"
         assert res.status == 201
 
-
-@test("body type validation")
-async def _():
+@pytest.mark.asyncio
+async def test_body_type_validation():
     app = new_app()
 
     @app.get("/")
@@ -129,9 +124,8 @@ async def _():
         assert res.status == 404
         assert res.message == "test"
 
-
-@test("query type validation")
-async def _():
+@pytest.mark.asyncio
+async def test_query_type_validation():
     app = new_app()
 
     @app.get("/")
@@ -171,9 +165,8 @@ async def _():
         assert res.status == 404
         assert res.message == "test"
 
-
-@test("queries directly from app and body")
-async def _():
+@pytest.mark.asyncio
+async def test_queries_directly_from_app_and_body():
     app = new_app()
 
     @app.query("name", str)
@@ -189,10 +182,9 @@ async def _():
     async with app.test() as test:
         assert (await test.get("/", query={"name": "test"})).message == "test"
         assert (await test.get("/body", body={"name": "test"})).message == "test"
-
-
-@test("response type")
-async def _():
+  
+@pytest.mark.asyncio
+async def test_response_type():
     app = new_app()
 
     @app.get("/")
@@ -206,9 +198,8 @@ async def _():
         assert res.status == 201
         assert res.headers["hello"] == "world"
 
-
-@test("object validation")
-async def _():
+@pytest.mark.asyncio
+async def test_object_validation():
     app = new_app()
 
     @dataclass
@@ -334,8 +325,8 @@ async def _():
         ).status == 400
 
 
-@test("dict validation")
-async def _():
+@pytest.mark.asyncio
+async def test_dict_validation():
     app = new_app()
 
     class Object(NamedTuple):
@@ -358,24 +349,8 @@ async def _():
         ).message
 
 
-@test("non async routes")
-async def _():
-    app = new_app()
-
-    @app.get("/")
-    def index():
-        return "hello world", 201, {"a": "b"}
-
-    async with app.test() as test:
-        res = await test.get("/")
-
-        assert res.message == "hello world"
-        assert res.status == 201
-        assert res.headers["a"] == "b"
-
-
-@test("list validation")
-async def _():
+@pytest.mark.asyncio
+async def test_list_validation():
     app = new_app()
 
     @app.get("/")
@@ -452,8 +427,8 @@ async def _():
         ).status == 400
 
 
-@test("auto route inputs")
-async def _():
+@pytest.mark.asyncio
+async def test_auto_route_inputs():
     @dataclass()
     class Data:
         a: str
@@ -488,8 +463,8 @@ async def _():
         assert res3.status == 201
 
 
-@test("attrs validation")
-async def _():
+@pytest.mark.asyncio
+async def test_attrs_validation():
     app = new_app()
 
     @attrs.define
@@ -529,8 +504,8 @@ async def _():
         ).message == "b"
 
 
-@test("caching")
-async def _():
+@pytest.mark.asyncio
+async def test_caching():
     app = new_app()
     count = 0
 
@@ -553,9 +528,9 @@ async def _():
         results = [(await test.get("/param_std")).message for _ in range(10)]
         assert all(i == results[0] for i in results)
 
-
-@test("synchronous route inputs")
-async def _():
+    
+@pytest.mark.asyncio
+async def test_asynchronous_route_inputs():
     app = new_app()
 
     @app.get("/")
@@ -582,8 +557,8 @@ async def _():
         ).message == "ab"
 
 
-@test("request data")
-async def _():
+@pytest.mark.asyncio
+async def test_request_data():
     app = new_app()
 
     @app.get("/")
@@ -626,8 +601,8 @@ async def _():
         ).message == "world"
 
 
-@test("context alongside other inputs")
-async def _():
+@pytest.mark.asyncio
+async def test_context_alongside_other_inputs():
     app = new_app()
 
     @app.get("/")
@@ -643,8 +618,8 @@ async def _():
         ).message == "abc"
 
 
-@test("middleware")
-async def _():
+@pytest.mark.asyncio
+async def test_middleware():
     app = new_app()
     value: bool = False
 
@@ -661,8 +636,8 @@ async def _():
         assert (await test.get("/")).message == "True"
 
 
-@test("middleware with parameters")
-async def _():
+@pytest.mark.asyncio
+async def test_middleware_with_parameters():
     app = new_app()
 
     @app.get("/")
@@ -691,8 +666,8 @@ async def _():
         await test.get("/both", query={"a": "a"}, body={"b": "b"})
 
 
-@test("methodless routes")
-async def _():
+@pytest.mark.asyncio
+async def test_methodless_routes():
     app = new_app()
 
     @app.route("/")
@@ -726,8 +701,8 @@ async def _():
         assert (await test.put("/methods")).status == 405
 
 
-@test("method not allowed errors")
-async def _():
+@pytest.mark.asyncio
+async def test_method_not_allowed_errors():
     app = new_app()
 
     @app.get("/")
@@ -741,8 +716,8 @@ async def _():
         assert res.message == "Method Not Allowed"
 
 
-@test("json response class")
-async def _():
+@pytest.mark.asyncio
+async def test_json_response_class():
     app = new_app()
 
     @app.get("/")
@@ -753,8 +728,8 @@ async def _():
         assert (await test.get("/")).message == '{"hello":"world"}'
 
 
-@test("body translate strategies")
-async def _():
+@pytest.mark.asyncio
+async def test_body_translate_strategies():
     app = new_app()
 
     @app.get("/")
@@ -779,4 +754,4 @@ async def _():
     async with app.test() as test:
         assert (await test.get("/")).message == repr("a")
         assert (await test.get("/result")).message == "{}"
-        assert (await test.get("/custom")).message == "1 2 3"
+        assert (await test.get("/custom")).message == "1 2 3" 

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -3,29 +3,27 @@ from dataclasses import dataclass
 from typing import Dict
 
 from typing_extensions import Annotated
-from ward import raises, test
 
-from view import (App, BadEnvironmentError, TypeValidationError, compile_type,
-                  env, get_app, new_app)
+import pytest
+from view import App, BadEnvironmentError, TypeValidationError, compile_type, env, get_app, new_app
 
-
-@test("app creation")
-def _():
+@pytest.mark.asyncio
+def test_app_creation():
     app = new_app()
     assert isinstance(app, App)
     app.load()
 
 
-@test("app fetching")
-def _():
+@pytest.mark.asyncio
+def test_app_fetching():
     app = new_app()
     assert isinstance(get_app(), App)
     app.load()
     assert app is get_app()
 
 
-@test("documentation generation")
-def _():
+@pytest.mark.asyncio
+def documentation_generation():
     app = new_app()
 
     @dataclass
@@ -84,8 +82,8 @@ def _():
     )
 
 
-@test("public typecode interface")
-async def _():
+@pytest.mark.asyncio
+async def test_public_typecode_interface():
     @dataclass
     class Test:
         a: str
@@ -105,12 +103,13 @@ async def _():
 
     assert not x
 
-    with raises(TypeValidationError):
+    with pytest.raises(TypeValidationError):
         tp.cast("{}")
 
-@test("environment variables")
-async def _():
-    with raises(BadEnvironmentError):
+
+@pytest.mark.asyncio
+async def test_environment_variables():
+    with pytest.raises(BadEnvironmentError):
         env("_TEST")
 
     os.environ["_TEST"] = "1"
@@ -125,3 +124,5 @@ async def _():
 
     os.environ["_TEST3"] = "false"
     assert env("_TEST3", tp=bool) is False
+
+    

--- a/tests/test_loaders.py
+++ b/tests/test_loaders.py
@@ -1,12 +1,12 @@
 from pathlib import Path
 
-from ward import test
+import pytest
 
 from view import delete, get, new_app, options, patch, post, put
 
 
-@test("manual loader")
-async def _():
+@pytest.mark.asyncio
+async def test_manual_loader():
     app = new_app()
     assert app.config.app.loader == "manual"
 
@@ -45,8 +45,8 @@ async def _():
         assert (await test.options("/options")).message == "options"
 
 
-@test("simple loader")
-async def _():
+@pytest.mark.asyncio
+async def test_simple_loader():
     app = new_app(config_path=Path.cwd() / "tests" / "configs" / "simple.toml")
 
     async with app.test() as test:
@@ -58,8 +58,8 @@ async def _():
         assert (await test.options("/options")).message == "options"
 
 
-@test("filesystem loader")
-async def _():
+@pytest.mark.asyncio
+async def test_filesystem_loader():
     app = new_app(config_path=Path.cwd() / "tests" / "configs" / "fs.toml")
 
     async with app.test() as test:
@@ -71,8 +71,8 @@ async def _():
         assert (await test.options("/options")).message == "options"
 
 
-@test("patterns loader")
-async def _():
+@pytest.mark.asyncio
+async def test_patterns_loader():
     app = new_app(config_path=Path.cwd() / "tests" / "configs" / "urls.toml")
 
     async with app.test() as test:

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -1,4 +1,4 @@
-from ward import raises, test
+import pytest
 
 from view import ERROR_CODES, Error, InvalidStatusError, new_app
 
@@ -24,8 +24,8 @@ STATUS_CODES = (
 )
 
 
-@test("returning the proper status code")
-async def _():
+@pytest.mark.asyncio
+async def test_returning_the_proper_status_code():
     app = new_app()
 
     @app.get("/")
@@ -38,10 +38,10 @@ async def _():
 
     @app.get("/fail")
     async def fail():
-        with raises(InvalidStatusError):
+        with pytest.raises(InvalidStatusError):
             raise Error(200)
 
-        with raises(InvalidStatusError):
+        with pytest.raises(InvalidStatusError):
             raise Error(600)
 
         return ""

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -1,12 +1,12 @@
 from pathlib import Path
 
-from ward import test
+import pytest
 
 from view import markdown, new_app, render, template
 
 
-@test("view rendering")
-async def _():
+@pytest.mark.asyncio
+async def test_view_rendering():
     x = 2
 
     class Test:
@@ -43,8 +43,8 @@ async def _():
     ) == "bye"
 
 
-@test("other engines")
-async def _():
+@pytest.mark.asyncio
+async def test_other_engines():
     x = "world"
     assert (await render("hello {{ x }}", engine="jinja")) == "hello world"
     assert (await render("hello {{ x }}", engine="django")) == "hello world"
@@ -52,8 +52,8 @@ async def _():
     assert (await render("hello ${x}", engine="chameleon")) == "hello world"
 
 
-@test("templating")
-async def _():
+@pytest.mark.asyncio
+async def test_templating():
     app = new_app()
 
     @app.get("/")
@@ -84,8 +84,8 @@ async def _():
         ) == "<!DOCTYPE html><html><h1>A</h1><h2>B</h2><h3>C</h3></html>"
 
 
-@test("template configuration settings")
-async def _():
+@pytest.mark.asyncio
+async def test_template_configuration_settings():
     app = new_app(config_path=Path.cwd() / "tests" / "configs" / "templates.toml")
 
     @app.get("/")
@@ -97,8 +97,8 @@ async def _():
         assert (await test.get("/")).message.replace("\n", "") == "1"
 
 
-@test("view renderer subtemplates")
-async def _():
+@pytest.mark.asyncio
+async def test_view_renderer_subtemplates():
     app = new_app(config_path=Path.cwd() / "tests" / "configs" / "subtemplates.toml")
 
     @app.get("/")


### PR DESCRIPTION
This pull request migrates the test suite from Ward to Pytest. The decision to migrate was made to leverage Pytest's robust features and better align with industry standards and community preferences.

Changes Made:
- Rewrote existing tests using Pytest syntax and assertions.
- Updated test fixtures and setup to align with Pytest conventions.
- Ensured compatibility with Pytest's async support for asynchronous tests.

Kindly! review it.